### PR TITLE
RESAS APIがエラーで返ってきたときに、HTTPErrorでキャッチをすり抜ける問題対応 + 細かな修正対応

### DIFF
--- a/src/components/common/CheckBox/index.ts
+++ b/src/components/common/CheckBox/index.ts
@@ -1,3 +1,3 @@
-import CheckBox from '@/components/common/CheckBox/CheckBox';
+import CheckBox from './CheckBox';
 
 export default CheckBox;

--- a/src/components/common/Header/index.ts
+++ b/src/components/common/Header/index.ts
@@ -1,3 +1,3 @@
-import Header from '@/components/common/Header/Header';
+import Header from './Header';
 
 export default Header;

--- a/src/components/model/Population/PopulationGraph/index.ts
+++ b/src/components/model/Population/PopulationGraph/index.ts
@@ -1,3 +1,3 @@
-import PopulationGraph from '@/components/model/Population/PopulationGraph/PopulationGraph';
+import PopulationGraph from './PopulationGraph';
 
 export default PopulationGraph;

--- a/src/components/model/Prefecture/PrefectureFieldset/index.tsx
+++ b/src/components/model/Prefecture/PrefectureFieldset/index.tsx
@@ -1,3 +1,3 @@
-import PrefectureFieldset from '@/components/model/Prefecture/PrefectureFieldset/PrefectureFieldset';
+import PrefectureFieldset from './PrefectureFieldset';
 
 export default PrefectureFieldset;

--- a/src/components/page/Home/Home.tsx
+++ b/src/components/page/Home/Home.tsx
@@ -38,13 +38,15 @@ const Home: VFC = () => {
           </div>
         ) : (
           // 都道府県 API データ取得成功時の UI
-          <div css={[container, mainLayout]}>
-            <PrefectureFieldset
-              prefectures={prefectures?.result}
-              handleCheck={handlePrefectureCheck}
-            />
-            <PopulationGraph data={populations} />
-          </div>
+          prefectures && (
+            <div css={[container, mainLayout]}>
+              <PrefectureFieldset
+                prefectures={prefectures?.result}
+                handleCheck={handlePrefectureCheck}
+              />
+              <PopulationGraph data={populations} />
+            </div>
+          )
         )}
       </main>
       <Toast isOpen={!!populationErrMsg} onClose={handleResetError}>

--- a/src/components/page/Home/index.ts
+++ b/src/components/page/Home/index.ts
@@ -1,3 +1,3 @@
-import HomePage from '@/components/page/Home/Home';
+import HomePage from './Home';
 
 export default HomePage;

--- a/src/config/ky.ts
+++ b/src/config/ky.ts
@@ -1,4 +1,8 @@
-import { Options } from 'ky';
+import { Options, NormalizedOptions } from 'ky';
+import {
+  isSimpleErrorResponse,
+  isMessageErrorResponse,
+} from '@/models/ErrorResponse';
 
 export const DEFAULT_API_OPTIONS: Options = {
   prefixUrl: 'https://opendata.resas-portal.go.jp/api/v1',
@@ -10,6 +14,37 @@ export const DEFAULT_API_OPTIONS: Options = {
           'X-API-KEY',
           process.env.NEXT_PUBLIC_RESAS_API_KEY ?? 'Not API Key'
         );
+      },
+    ],
+    afterResponse: [
+      async (
+        _request: Request,
+        _options: NormalizedOptions,
+        response: Response
+      ): Promise<Response> => {
+        const { headers, status, statusText } = response;
+        let init = { headers, status, statusText };
+        const data = await response.json();
+
+        // RESAS API はエラー時にもヘッダーのステータスコードが200で返ってくることがあるので、詰めなおす
+        // 400, 404（レスポンスボディがステータスコードだけの場合）
+        if (isSimpleErrorResponse(data)) {
+          init = { headers, status: parseInt(data), statusText: '' };
+        }
+
+        // 403, 404の場合
+        if (isMessageErrorResponse(data)) {
+          init = {
+            headers,
+            status: parseInt(data.statusCode),
+            statusText: data.message,
+          };
+        }
+
+        const body = new Blob([JSON.stringify(data, null, 2)], {
+          type: 'application/json',
+        });
+        return new Response(body, init);
       },
     ],
   },

--- a/src/models/ErrorResponse.ts
+++ b/src/models/ErrorResponse.ts
@@ -1,0 +1,25 @@
+export type SimpleErrorResponse = '400' | '404';
+
+export type MessageErrorResponse = {
+  statusCode: '403' | '404';
+  message: string;
+  description: string;
+};
+
+const isSimpleErrorResponse = (arg: unknown): arg is SimpleErrorResponse => {
+  const err = arg as SimpleErrorResponse;
+
+  return err === '400' || err === '404';
+};
+
+const isMessageErrorResponse = (arg: unknown): arg is MessageErrorResponse => {
+  const err = arg as MessageErrorResponse;
+
+  return (
+    (err.statusCode === '403' || err.statusCode === '404') &&
+    typeof err.message === 'string' &&
+    typeof err.description === 'string'
+  );
+};
+
+export { isSimpleErrorResponse, isMessageErrorResponse };

--- a/src/pages/api/hello.ts
+++ b/src/pages/api/hello.ts
@@ -1,6 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import { NextApiRequest, NextApiResponse } from 'next';
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.status(200).json({ name: 'John Doe' });
-}


### PR DESCRIPTION
## Issue 番号
closes #9 

## 対応内容
- RESAS API がエラーを返した + ヘッダーステータスコードが200の時に、レスポンスボディから本来のステータスコードを取り出してセットしなおす後処理を追加
- 使用していない API ルートを削除
- 再エクスポート用 index.ts のインポート元 URL を相対パスに修正
- ページ初回読み込み時に、都道府県ブロックが一瞬ちらつく問題修正