### PR TITLE
読み込み中stateをfalseにするタイミング修正、VSCode拡張識別子修正

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,7 +10,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "stylelint.vscode-stylelint",
-    "jpoissonnier.vscode-styled-components"
+    "styled-components.vscode-styled-components"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/src/hooks/usePopulation.ts
+++ b/src/hooks/usePopulation.ts
@@ -55,7 +55,6 @@ const usePopulation = () => {
                 prefName,
                 payload: totalPopulation,
               });
-              setIsLoading(false);
               setErrorMessage('');
             })
             .catch((err) => {
@@ -68,6 +67,8 @@ const usePopulation = () => {
               } else {
                 console.error(err);
               }
+            })
+            .finally(() => {
               setIsLoading(false);
             });
         } else {

--- a/src/hooks/usePrefecture.ts
+++ b/src/hooks/usePrefecture.ts
@@ -15,7 +15,6 @@ const usePrefecture = () => {
     getPrefectures()
       .then((data) => {
         setPrefectures(data);
-        setIsLoading(false);
         setErrorMessage('');
       })
       .catch((err) => {
@@ -28,6 +27,8 @@ const usePrefecture = () => {
         } else {
           console.error(err);
         }
+      })
+      .finally(() => {
         setIsLoading(false);
       });
   }, []);


### PR DESCRIPTION
## Issue 番号
closes #13 

## 対応内容
- 各種カスタムフックで、読み込み中 state を false にするタイミングを finally ブロックに修正
- styled-components の VSCode 拡張の識別子を、公式のものに更新